### PR TITLE
Remove hashCode from itemViewType

### DIFF
--- a/kiel/src/main/java/me/ibrahimyilmaz/kiel/item/LayoutResourceRenderer.kt
+++ b/kiel/src/main/java/me/ibrahimyilmaz/kiel/item/LayoutResourceRenderer.kt
@@ -6,4 +6,7 @@ interface LayoutResourceRenderer<out T : Any> : Renderer<T> {
 
     @get:LayoutRes
     val layoutRes: Int
+
+    override val itemViewType: Int
+        get() = layoutRes
 }

--- a/kiel/src/main/java/me/ibrahimyilmaz/kiel/item/Renderer.kt
+++ b/kiel/src/main/java/me/ibrahimyilmaz/kiel/item/Renderer.kt
@@ -18,5 +18,5 @@ interface Renderer<out T : Any> {
         payload: List<Any>
     ) = render(view, item)
 
-    val itemViewType: Int get() = javaClass.hashCode()
+    val itemViewType: Int
 }


### PR DESCRIPTION
The main idea was to find unique identifier for itemViewType. HashCode could be a good candidate.
But the main detail about hashcode  is that it is Integer. And we can't directly trust on this.

PS: Also one thing that we should remember, Java itself HashCode's this problem with equals method in HashMap. 