### PR TITLE
Item Id configuration implementation

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -25,6 +25,6 @@ ext.versions = [
         mockitoKotlinVersion: '2.2.0',
         mockitoInlineVersion: '3.3.3',
         androidxTestJunit   : '1.1.1',
-        espressoVersion     : '3.2.0'
-
+        espressoVersion     : '3.2.0',
+        robolectricVersion  : '4.3.1',
 ]

--- a/kiel/build.gradle
+++ b/kiel/build.gradle
@@ -62,4 +62,5 @@ dependencies {
     testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:$versions.mockitoKotlinVersion"
     testImplementation "org.mockito:mockito-inline:$versions.mockitoInlineVersion"
     testImplementation "com.google.truth:truth:$versions.truthVersion"
+    testImplementation "org.robolectric:robolectric:$versions.robolectricVersion"
 }

--- a/kiel/src/main/java/me/ibrahimyilmaz/kiel/adapter/ItemIdProvider.kt
+++ b/kiel/src/main/java/me/ibrahimyilmaz/kiel/adapter/ItemIdProvider.kt
@@ -1,0 +1,7 @@
+package me.ibrahimyilmaz.kiel.adapter
+
+typealias ItemIdProviderOperator<T> = (item: T) -> Long
+
+interface ItemIdProvider<T> {
+    fun provideId(item: T): Long
+}

--- a/kiel/src/test/java/me/ibrahimyilmaz/kiel/adapter/RecyclerAdapterItemIdProviderTest.kt
+++ b/kiel/src/test/java/me/ibrahimyilmaz/kiel/adapter/RecyclerAdapterItemIdProviderTest.kt
@@ -1,0 +1,47 @@
+package me.ibrahimyilmaz.kiel.adapter
+
+import android.os.Build
+import com.google.common.truth.Truth.assertThat
+import com.nhaarman.mockitokotlin2.mock
+import me.ibrahimyilmaz.kiel.datasource.RecyclerDataSource
+import me.ibrahimyilmaz.kiel.datasource.util.TestItem
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@Config(sdk = [Build.VERSION_CODES.P])
+@RunWith(RobolectricTestRunner::class)
+class RecyclerAdapterItemIdProviderTest {
+
+    @Mock
+    private lateinit var dataSource: RecyclerDataSource<TestItem>
+
+    private lateinit var recyclerAdapter: RecyclerAdapter<TestItem>
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.initMocks(this)
+    }
+
+    @Test
+    fun `Should have stable id when the item id provider is provided`() {
+        // WHEN
+        recyclerAdapter = RecyclerAdapter(dataSource, mock())
+
+        // THEN
+        assertThat(recyclerAdapter.hasStableIds()).isTrue()
+    }
+
+    @Test
+    fun `Should not have stable id when the item id provider is not provided`() {
+        // WHEN
+        recyclerAdapter = RecyclerAdapter(dataSource)
+
+        // THEN
+        assertThat(recyclerAdapter.hasStableIds()).isFalse()
+    }
+}


### PR DESCRIPTION
The items of RecyclerView may have `id`. Then we can use them to be able to use setHasStableIds(true).

Example:
```
data class Item(val id:Long,val name:String)
val recyclerAdapter = RecyclerAdapter<Item>(dataSource, {it.id})

```