### PR TITLE
Release/1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ### Development
+- onBindBindViewHolder typo fixed.
 - downgrade minSdk 16.
 
 ### Tahat(1.2.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ### Development
+- downgrade minSdk 16.
 
 ### Tahat(1.2.0)
 - pagingDataAdapter introduced.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ### Development
+
+### Tahat(1.2.1)
 - onBindBindViewHolder typo fixed.
 - downgrade minSdk 16.
 

--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 [![Android Arsenal](https://img.shields.io/badge/Android%20Arsenal-Kiel-brightgreen.svg?style=flat)](https://android-arsenal.com/details/1/8140)
 ## Kiel
 
-Kiel is a `RecyclerView.Adapter` with a minimalist and convenient Kotlin DSL which provides utility on top of Android's normal `RecyclerView.Adapter`.
+Kiel is a `RecyclerView.Adapter` with a minimalistic and convenient Kotlin DSL which provides utility on top of Android's normal `RecyclerView.Adapter`.
 
 <img alt="kiel_icon" src="art/kiel_icon.svg" width="250">
 
-Most of time:
-- We found ourselves  repeating same boiler plate codes for `RecyclerView.Adapter`.
+Most of the time:
+- We found ourselves repeating same boilerplate code for `RecyclerView.Adapter`.
 - We have difficulty in handling `RecyclerView.Adapter` when there are many `viewTypes`.
 
 But now, Kiel may help us to get rid of these problems.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![build](https://github.com/ibrahimyilmaz/kiel/workflows/build/badge.svg)
 [ ![Download](https://api.bintray.com/packages/ibrahimyilmaz/kiel/kiel/images/download.svg) ](https://bintray.com/ibrahimyilmaz/kiel/kiel/_latestVersion)
-
+[![Android Arsenal](https://img.shields.io/badge/Android%20Arsenal-Kiel-brightgreen.svg?style=flat)](https://android-arsenal.com/details/1/8140)
 ## Kiel
 
 Kiel is a `RecyclerView.Adapter` with a minimalist and convenient Kotlin DSL which provides utility on top of Android's normal `RecyclerView.Adapter`.

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -2,7 +2,7 @@ ext.versions = [
         minSdk                    : 16,
         compileSdk                : 29,
         versionCode               : 0,
-        versionName               : '1.2.0',
+        versionName               : '1.2.1',
 
         // gradle plugins
         gradleBuildTool           : '4.0.0',

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,5 +1,5 @@
 ext.versions = [
-        minSdk                    : 19,
+        minSdk                    : 16,
         compileSdk                : 29,
         versionCode               : 0,
         versionName               : '1.2.0',

--- a/kiel/src/main/AndroidManifest.xml
+++ b/kiel/src/main/AndroidManifest.xml
@@ -1,5 +1,1 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="me.ibrahimyilmaz.kiel">
-
-    /
-</manifest>
+<manifest package="me.ibrahimyilmaz.kiel" />

--- a/kiel/src/main/java/me/ibrahimyilmaz/kiel/core/AdapterBuilder.kt
+++ b/kiel/src/main/java/me/ibrahimyilmaz/kiel/core/AdapterBuilder.kt
@@ -109,7 +109,7 @@ class AdapterBuilder<T : Any> {
         @LayoutRes
         layoutResource: Int,
         noinline onViewHolderCreated: OnViewHolderCreated<VH>? = null,
-        noinline onBindBindViewHolder: OnBindViewHolder<P, VH>? = null,
+        noinline onBindViewHolder: OnBindViewHolder<P, VH>? = null,
         noinline onBindViewHolderWithPayload: OnBindViewHolderWithPayload<P, VH>? = null
     ) {
         val itemType = P::class.java
@@ -131,7 +131,7 @@ class AdapterBuilder<T : Any> {
             registerViewHolderCreatedListener(layoutResource, onViewHolderCreatedListener)
         }
 
-        onBindBindViewHolder?.let {
+        onBindViewHolder?.let {
             val onBindViewHolderListener = object : OnBindViewHolder<T, RecyclerViewHolder<T>> {
                 override fun invoke(viewHolder: RecyclerViewHolder<T>, position: Int, item: T) =
                     it(viewHolder as VH, position, item as P)

--- a/samples/build.gradle
+++ b/samples/build.gradle
@@ -45,12 +45,12 @@ dependencies {
     implementation "androidx.navigation:navigation-fragment-ktx:$versions.navigationVersion"
     implementation "androidx.navigation:navigation-ui-ktx:$versions.navigationVersion"
     implementation "androidx.recyclerview:recyclerview:$versions.recyclerViewVersion"
+    implementation project(path: ':kiel')
     def lifecycle_version = "2.2.0-rc03"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycle_version"
     implementation "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycle_version"
     kapt "androidx.lifecycle:lifecycle-compiler:$lifecycle_version"
 
-    implementation "me.ibrahimyilmaz:kiel:1.1.0"
     // Glide
     implementation "com.github.bumptech.glide:glide:$versions.glideVersion"
     implementation "com.github.florent37:glidepalette:$versions.glidePaletteVersion"

--- a/samples/build.gradle
+++ b/samples/build.gradle
@@ -7,7 +7,7 @@ android {
     compileSdkVersion versions.compileSdk
     defaultConfig {
         applicationId "me.ibrahimyilmaz.kiel.samples"
-        minSdkVersion versions.minSdk
+        minSdkVersion 19
         targetSdkVersion versions.compileSdk
         versionCode 1
         versionName "1.0"

--- a/samples/src/main/java/me/ibrahimyilmaz/kiel/samples/adapter/AdapterExampleFragment.kt
+++ b/samples/src/main/java/me/ibrahimyilmaz/kiel/samples/adapter/AdapterExampleFragment.kt
@@ -5,7 +5,7 @@ import android.view.View
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
-import me.ibrahimyilmaz.kiel.adapter.RecyclerViewAdapter.Companion.adapterOf
+import me.ibrahimyilmaz.kiel.adapterOf
 import me.ibrahimyilmaz.kiel.samples.R
 import me.ibrahimyilmaz.kiel.samples.adapter.model.MessageViewState
 import me.ibrahimyilmaz.kiel.samples.adapter.model.MessageViewState.Image
@@ -26,53 +26,52 @@ class AdapterExampleFragment : Fragment(R.layout.fragment_adapter_example) {
         super.onViewCreated(view, savedInstanceState)
         messagesRecyclerView = view.findViewById(R.id.messagesRecyclerView)
 
-        val recyclerViewAdapter =
-            adapterOf<MessageViewState> {
-                register(
-                    layoutResource = R.layout.adapter_message_text_item,
-                    viewHolder = ::TextMessageViewHolder,
-                    onBindBindViewHolder = { vh, _, text ->
-                        vh.messageText.text = text.text
-                        vh.sentAt.text = text.sentAt
+        val recyclerViewAdapter = adapterOf<MessageViewState> {
+            register(
+                layoutResource = R.layout.adapter_message_text_item,
+                viewHolder = ::TextMessageViewHolder,
+                onBindViewHolder = { vh, _, text ->
+                    vh.messageText.text = text.text
+                    vh.sentAt.text = text.sentAt
+                }
+            )
+
+            register(
+                layoutResource = R.layout.adapter_message_image_item,
+                viewHolder = ::ImageMessageViewHolder,
+                onBindViewHolder = { vh, _, item ->
+                    vh.messageText.text = item.text
+                    vh.sentAt.text = item.sentAt
+
+                    Glide.with(vh.messageImage)
+                        .load(item.imageUrl)
+                        .into(vh.messageImage)
+                }
+            )
+
+            register(
+                layoutResource = R.layout.adapter_message_poll_item,
+                viewHolder = ::PollMessageViewHolder,
+                onBindViewHolder = { vh, _, poll ->
+                    vh.pollTitle.text = poll.text
+                    vh.sentAt.text = poll.sentAt
+
+                    val pollOptionsAdapter = adapterOf<PollOption> {
+                        register(
+                            layoutResource = R.layout.adapter_poll_option_item,
+                            viewHolder = ::PollOptionViewHolder,
+                            onBindViewHolder = { pollOptionViewHolder, _, pollOption ->
+                                pollOptionViewHolder.pollOption.text = pollOption.text
+                            }
+                        )
                     }
-                )
 
-                register(
-                    layoutResource = R.layout.adapter_message_image_item,
-                    viewHolder = ::ImageMessageViewHolder,
-                    onBindBindViewHolder = { vh, _, item ->
-                        vh.messageText.text = item.text
-                        vh.sentAt.text = item.sentAt
+                    vh.pollOptionsRecyclerView.adapter = pollOptionsAdapter
 
-                        Glide.with(vh.messageImage)
-                            .load(item.imageUrl)
-                            .into(vh.messageImage)
-                    }
-                )
-
-                register(
-                    layoutResource = R.layout.adapter_message_poll_item,
-                    viewHolder = ::PollMessageViewHolder,
-                    onBindBindViewHolder = { vh, _, poll ->
-                        vh.pollTitle.text = poll.text
-                        vh.sentAt.text = poll.sentAt
-
-                        val pollOptionsAdapter = adapterOf<PollOption> {
-                            register(
-                                layoutResource = R.layout.adapter_poll_option_item,
-                                viewHolder = ::PollOptionViewHolder,
-                                onBindBindViewHolder = { pollOptionViewHolder, _, pollOption ->
-                                    pollOptionViewHolder.pollOption.text = pollOption.text
-                                }
-                            )
-                        }
-
-                        vh.pollOptionsRecyclerView.adapter = pollOptionsAdapter
-
-                        pollOptionsAdapter.submitList(poll.options)
-                    }
-                )
-            }
+                    pollOptionsAdapter.submitList(poll.options)
+                }
+            )
+        }
 
         messagesRecyclerView.adapter =
             recyclerViewAdapter

--- a/samples/src/main/java/me/ibrahimyilmaz/kiel/samples/listadapter/DiffExampleFragment.kt
+++ b/samples/src/main/java/me/ibrahimyilmaz/kiel/samples/listadapter/DiffExampleFragment.kt
@@ -8,7 +8,7 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.RecyclerView
-import me.ibrahimyilmaz.kiel.adapter.RecyclerViewAdapter.Companion.adapterOf
+import me.ibrahimyilmaz.kiel.adapterOf
 import me.ibrahimyilmaz.kiel.samples.R
 import me.ibrahimyilmaz.kiel.samples.listadapter.model.MessageListItemViewState
 import me.ibrahimyilmaz.kiel.samples.listadapter.model.MessageSelectionState
@@ -90,7 +90,7 @@ class DiffExampleFragment :
                     true
                 }
             },
-            onBindBindViewHolder = { messageViewHolder, _, messageListItemViewState ->
+            onBindViewHolder = { messageViewHolder, _, messageListItemViewState ->
                 messageViewHolder.binding.senderText.text = messageListItemViewState.message.sender
                 messageViewHolder.binding.contentText.text =
                     messageListItemViewState.message.content


### PR DESCRIPTION
### Tahat(1.2.1)
- onBindBindViewHolder typo fixed.
- downgrade minSdk 16.

### Tahat(1.2.0)
- pagingDataAdapter introduced.
- Kotlin 1.4.0 bump

### Tillamook(1.1.0)
- ktlint integration.
- composable diff introduced.
- AdapterRegistryBuilder deprecated.

### Twin Peaks(1.0.2)
- diffUtilCallback created
### Twin Peaks(1.0.1)
- adaptersOf type corrected.
### Twin Peaks(1.0.0)
- RecyclerViewAdapter and adapterOf builder function introduced.
