### PR TITLE
Remove jcenter from kiel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ### Development
+- Drop JCenter https://blog.gradle.org/jcenter-shutdown
 - Drop Jetifier.
 - Drop Glide Palette library.
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,6 @@ buildscript {
 
     repositories {
         google()
-        jcenter()
         maven {
             url "https://plugins.gradle.org/m2/"
         }
@@ -21,7 +20,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     tasks.withType(Javadoc) {

--- a/samples/build.gradle
+++ b/samples/build.gradle
@@ -57,8 +57,6 @@ dependencies {
 
     //CircleImageView
     implementation 'de.hdodenhof:circleimageview:3.1.0'
-    implementation 'com.amulyakhare:com.amulyakhare.textdrawable:1.0.1'
-
 
     testImplementation "junit:junit:$versions.junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$versions.androidxTestJunit"


### PR DESCRIPTION
## Proposed Changes/Issues Fixed

Before publishing kiel to Maven Central, jcenter should be removed.
## General

  - [x] Change/Fix added to `CHANGELOG.md`
  - [x] Issue Link https://github.com/ibrahimyilmaz/kiel/issues/72

## Testing
  - [x] `Monkey-Test` done
  - [x] Does your submission pass `./gradlew check`?